### PR TITLE
feat: Make the color palette draggable

### DIFF
--- a/index.html
+++ b/index.html
@@ -160,7 +160,7 @@
 
     <!-- 浮動調色盤 -->
     <div id="floating-palette" class="hidden">
-        <h4 class="palette-title">專案顏色</h4>
+        <div id="palette-header" class="palette-title">專案顏色</div>
         <div id="palette-swatches" class="swatch-container">
             <!-- 顏色樣本將由 JS 動態生成 -->
         </div>

--- a/js/UIManager.js
+++ b/js/UIManager.js
@@ -36,6 +36,7 @@ class UIManager {
 
         // --- 浮動調色盤 ---
         this.floatingPalette = document.querySelector('#floating-palette');
+        this.paletteHeader = document.querySelector('#palette-header'); // 新增標頭參照
         this.paletteSwatches = document.querySelector('#palette-swatches');
 
         // --- 模式按鈕 ---
@@ -83,6 +84,63 @@ class UIManager {
 
         // 專案管理
         this.projectNameInput.addEventListener('input', (e) => this.stateManager.setProjectName(e.target.value));
+
+        // 設定浮動調色盤可拖動
+        this.setupPaletteDragging();
+    }
+
+    setupPaletteDragging() {
+        let isDragging = false;
+        let offsetX, offsetY;
+
+        const onMouseDown = (e) => {
+            isDragging = true;
+            // 計算滑鼠點擊位置相對於調色盤左上角的偏移
+            offsetX = e.clientX - this.floatingPalette.offsetLeft;
+            offsetY = e.clientY - this.floatingPalette.offsetTop;
+
+            // 移除可能影響拖曳的 transition 效果
+            this.floatingPalette.style.transition = 'none';
+
+            document.addEventListener('mousemove', onMouseMove);
+            document.addEventListener('mouseup', onMouseUp);
+        };
+
+        const onMouseMove = (e) => {
+            if (!isDragging) return;
+
+            // 計算調色盤的新位置
+            let newX = e.clientX - offsetX;
+            let newY = e.clientY - offsetY;
+
+            // 確保調色盤不會被拖出視窗外
+            const paletteRect = this.floatingPalette.getBoundingClientRect();
+            const bodyRect = document.body.getBoundingClientRect();
+
+            if (newX < 0) newX = 0;
+            if (newY < 0) newY = 0;
+            if (newX + paletteRect.width > bodyRect.width) newX = bodyRect.width - paletteRect.width;
+            if (newY + paletteRect.height > bodyRect.height) newY = bodyRect.height - paletteRect.height;
+
+
+            this.floatingPalette.style.left = `${newX}px`;
+            this.floatingPalette.style.top = `${newY}px`;
+
+            // 拖曳時移除 bottom 和 transform 樣式，以 left/top 為主
+            this.floatingPalette.style.bottom = 'auto';
+            this.floatingPalette.style.transform = 'none';
+        };
+
+        const onMouseUp = () => {
+            isDragging = false;
+            // 恢復 transition 效果
+            this.floatingPalette.style.transition = 'opacity 0.3s ease, transform 0.3s ease';
+
+            document.removeEventListener('mousemove', onMouseMove);
+            document.removeEventListener('mouseup', onMouseUp);
+        };
+
+        this.paletteHeader.addEventListener('mousedown', onMouseDown);
     }
 
     // --- 事件處理函式 ---

--- a/style.css
+++ b/style.css
@@ -315,6 +315,11 @@ input[type="range"]:hover::-webkit-slider-thumb { background-color: var(--primar
     text-align: center;
 }
 
+#palette-header {
+    cursor: move;
+    padding-bottom: 5px; /* 增加一些底部空間 */
+}
+
 .swatch-container {
     display: grid;
     grid-template-columns: repeat(5, 1fr);


### PR DESCRIPTION
This commit introduces drag-and-drop functionality for the floating color palette.

Key changes:
- Added a header element to the palette in `index.html` to serve as a dedicated drag handle.
- Styled the header with a "move" cursor in `style.css` for better user experience.
- Implemented the dragging logic in `js/UIManager.js`, including:
  - Event listeners for mousedown, mousemove, and mouseup.
  - Calculation of the new palette position.
  - Boundary checks to keep the palette within the viewport.

This allows users to freely reposition the palette without interfering with the existing functionality of selecting colors from the swatches.