### PR TITLE
fix: Make color palette draggable and fix selection bug

### DIFF
--- a/js/UIManager.js
+++ b/js/UIManager.js
@@ -87,6 +87,17 @@ class UIManager {
 
         // 設定浮動調色盤可拖動
         this.setupPaletteDragging();
+
+        // 使用事件委派處理調色盤點擊，這樣動態新增的元素也能響應
+        this.paletteSwatches.addEventListener('click', (event) => {
+            const swatch = event.target.closest('.color-swatch');
+            if (swatch && swatch.dataset.color) {
+                const clickedColor = swatch.dataset.color;
+                // 我們可以直接呼叫狀態管理器來更新顏色
+                // stateManager 會通知 UI 更新，包括更新 particleColorInput 的值
+                this.stateManager.setParticleSettings('reddust', clickedColor);
+            }
+        });
     }
 
     setupPaletteDragging() {
@@ -231,12 +242,7 @@ class UIManager {
                 swatch.style.backgroundColor = color;
                 swatch.dataset.color = color; // 將顏色儲存在 data 屬性中
                 swatch.title = color;
-                swatch.addEventListener('click', (event) => {
-                    // 直接從被點擊的元素讀取顏色，避免閉包問題
-                    const clickedColor = event.target.dataset.color;
-                    this.particleColorInput.value = clickedColor;
-                    this.stateManager.setParticleSettings('reddust', clickedColor);
-                });
+                // 事件監聽器已移至 setupEventListeners 中，此處不再需要
                 this.paletteSwatches.appendChild(swatch);
             });
         }


### PR DESCRIPTION
This commit resolves an issue where clicking on a color swatch in the floating palette did not update the current color. It also includes the previously implemented drag-and-drop functionality for the palette.

Key changes:
- Refactored the color swatch click handling in `js/UIManager.js` to use event delegation. This is a more robust approach that prevents event listeners from being lost during UI re-renders.
- Added a dedicated header element to the palette in `index.html` to serve as a drag handle.
- Styled the header with a `cursor: move` style in `style.css`.
- Implemented the dragging logic in `js/UIManager.js`, with boundary checks to keep the palette within the viewport.

The palette is now fully functional, allowing users to both reposition it on the screen and correctly select colors.